### PR TITLE
Added parentActivityName tag to MessagePreferenceActivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -175,6 +175,7 @@
         </activity>
 
         <activity android:name=".ui.MessagingPreferenceActivity"
+            android:parentActivityName=".ui.ConversationList"
             android:theme="@style/MmsHoloTheme"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/preferences_title" />


### PR DESCRIPTION
Added parentActivityName tag to MessagePreferenceActivity in order to fix navigation. Earlier if you went to the ComposeMessageActivity and pressed up on the Action Bar you would go back to ComposeMessageActivity instead of going "up" to ConversationList.
