### PR TITLE
Put Settings at the bottom of the menu

### DIFF
--- a/res/menu/conversation_list_menu.xml
+++ b/res/menu/conversation_list_menu.xml
@@ -27,10 +27,6 @@
           android:showAsAction="ifRoom|collapseActionView"
           android:actionViewClass="android.widget.SearchView" />
 
-    <item android:id="@+id/action_settings"
-        android:title="@string/menu_preferences"
-        android:icon="@android:drawable/ic_menu_preferences" />
-
     <item android:id="@+id/action_delete_all"
         android:title="@string/menu_delete_all"
         android:icon="@drawable/ic_menu_trash_holo_dark" />
@@ -40,4 +36,8 @@
 
     <item android:id="@+id/action_debug_dump"
         android:title="@string/menu_debug_dump" />
+        
+     <item android:id="@+id/action_settings"
+        android:title="@string/menu_preferences"
+        android:icon="@android:drawable/ic_menu_preferences" />
 </menu>


### PR DESCRIPTION
Put Settings at the bottom of the menu in order to follow the Android Design Guidelines. Link is here: http://developer.android.com/design/patterns/settings.html
