### PR TITLE
Removed old up navigation

### DIFF
--- a/src/com/android/mms/ui/MessagingPreferenceActivity.java
+++ b/src/com/android/mms/ui/MessagingPreferenceActivity.java
@@ -225,12 +225,6 @@ public class MessagingPreferenceActivity extends PreferenceActivity
             case MENU_RESTORE_DEFAULTS:
                 restoreDefaultPreferences();
                 return true;
-
-            case android.R.id.home:
-                // The user clicked on the Messaging icon in the action bar. Take them back from
-                // wherever they came from
-                finish();
-                return true;
         }
         return false;
     }


### PR DESCRIPTION
Removed up navigation in favor of android:parentActivityName tag in AndroidManifest.xml which is more accurate when it come to navigation up and not back. Should not be added to master branch until AndroidManifest.xml commit has been approved.
